### PR TITLE
Remove unnecessary ANativeWindow_SetBuffersGeometry() call.

### DIFF
--- a/samples-android/Common/ndk_helper/GLContext.cpp
+++ b/samples-android/Common/ndk_helper/GLContext.cpp
@@ -136,14 +136,6 @@ bool GLContext::InitEGLSurface() {
   eglQuerySurface(display_, surface_, EGL_WIDTH, &screen_width_);
   eglQuerySurface(display_, surface_, EGL_HEIGHT, &screen_height_);
 
-  /* EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is
-   * guaranteed to be accepted by ANativeWindow_setBuffersGeometry().
-   * As soon as we picked a EGLConfig, we can safely reconfigure the
-   * ANativeWindow buffers to match, using EGL_NATIVE_VISUAL_ID. */
-  EGLint format;
-  eglGetConfigAttrib(display_, config_, EGL_NATIVE_VISUAL_ID, &format);
-  ANativeWindow_setBuffersGeometry(window_, 0, 0, format);
-
   return true;
 }
 

--- a/samples-android/Minimalist/src/main/jni/main.cpp
+++ b/samples-android/Minimalist/src/main/jni/main.cpp
@@ -94,7 +94,7 @@ static int engine_init_display(struct engine* engine) {
   const EGLint attribs[] = {EGL_SURFACE_TYPE, EGL_WINDOW_BIT, EGL_BLUE_SIZE,
                             8,                EGL_GREEN_SIZE, 8,
                             EGL_RED_SIZE,     8,              EGL_NONE};
-  EGLint w, h, dummy, format;
+  EGLint w, h, dummy;
   EGLint numConfigs;
   EGLConfig config;
   EGLSurface surface;
@@ -108,14 +108,6 @@ static int engine_init_display(struct engine* engine) {
    * sample, we have a very simplified selection process, where we pick
    * the first EGLConfig that matches our criteria */
   eglChooseConfig(display, attribs, &config, 1, &numConfigs);
-
-  /* EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is
-   * guaranteed to be accepted by ANativeWindow_setBuffersGeometry().
-   * As soon as we picked a EGLConfig, we can safely reconfigure the
-   * ANativeWindow buffers to match, using EGL_NATIVE_VISUAL_ID. */
-  eglGetConfigAttrib(display, config, EGL_NATIVE_VISUAL_ID, &format);
-
-  ANativeWindow_setBuffersGeometry(engine->app->window, 0, 0, format);
 
   surface = eglCreateWindowSurface(display, config, engine->app->window, NULL);
   context = eglCreateContext(display, config, NULL, NULL);


### PR DESCRIPTION
- We don't have to call the API unless want to have different buffer size than
  the native resolution.
- This was causing broken rendering on some devices.