### PR TITLE
made ButtonClicker target abi armeabi-v7a rather than arm64-v8a

### DIFF
--- a/samples-android/ButtonClicker/src/main/jni/Application.mk
+++ b/samples-android/ButtonClicker/src/main/jni/Application.mk
@@ -1,6 +1,6 @@
 APP_PLATFORM := android-22
-#APP_ABI := armeabi-v7a
-APP_ABI := arm64-v8a
+APP_ABI := armeabi-v7a
+#APP_ABI := arm64-v8a
 APP_STL := c++_static
 
 APP_CPPFLAGS := -std=c++11


### PR DESCRIPTION
https://github.com/playgameservices/cpp-android-basic-samples/issues/32

I don't think ButtonClicker should target arm64-v8a by default. That ABI is very niche. Most devices can emulate armeabi-v7a if they dont support it natively. This makes much more sense.