### PR TITLE
made ButtonClicker target abi armeabi-v7a rather than arm64-v8a

### DIFF
--- a/samples-android/ButtonClicker/src/main/jni/Application.mk
+++ b/samples-android/ButtonClicker/src/main/jni/Application.mk
@@ -1,6 +1,5 @@
 APP_PLATFORM := android-22
-#APP_ABI := armeabi-v7a
-APP_ABI := arm64-v8a
+APP_ABI := armeabi-v7a
 APP_STL := c++_static
 
 APP_CPPFLAGS := -std=c++11


### PR DESCRIPTION
Most non arm devices emulate arm just fine. This ABI is niche and shouldn't be the default target ABI of this sample project.