### PR TITLE
made ButtonClicker target abi armeabi-v7a rather than arm64-v8a

### DIFF
--- a/samples-android/ButtonClicker/src/main/jni/Application.mk
+++ b/samples-android/ButtonClicker/src/main/jni/Application.mk
@@ -1,6 +1,5 @@
 APP_PLATFORM := android-22
-#APP_ABI := armeabi-v7a
-APP_ABI := arm64-v8a
+APP_ABI := armeabi-v7a
 APP_STL := c++_static
 
 APP_CPPFLAGS := -std=c++11


### PR DESCRIPTION
The ButtonClicker sample shouldn't use a niche ABI by default. This causes an extra layer of confusion when trying to run and install the sample application on most devices. The other samples don't target this niche ABI and it's not documented anywhere.